### PR TITLE
Initialize Users as a slice rather than an array

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func readUsers() []User {
 
 	defer file.Close()
 
-	var users []User
+	var users []User = make([]User, 0)
 	decoder := json.NewDecoder(file)
 	err = decoder.Decode(&users)
 	if err != nil {


### PR DESCRIPTION
Issue #4 
This fixed the issue where after 5 users had been generated, any new users generated overwrote the last user in the array 